### PR TITLE
Fix: 잘못된 eslintrc plugin import 수정

### DIFF
--- a/src/client/.eslintrc
+++ b/src/client/.eslintrc
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "plugins": ["eslint-config-airbnb-base", "eslint-plugin-react"],
+  "plugins": ["eslint-config-airbnb", "eslint-plugin-react"],
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",


### PR DESCRIPTION
설정 중에 잘못된 import 가 발견되어 수정하여 올립니다.

hotfix 브랜치를 사용했어야 하는데 급해서 main에서 한 점 양해 부탁드립니다.